### PR TITLE
Add an index.html page at the root to redirect to the PDF viewer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# PDF Viewer
+
+This is a web-based PDF viewer. It can be used to display PDF files in a browser.
+
+## Usage
+
+To view a PDF file, provide the file path in the `file` query parameter.
+
+Example:
+`https://tarosay.github.io/pdfs-viewer/web/viewer.html?file=YOUR_FILE.pdf`
+
+If you access the root URL (`https://tarosay.github.io/pdfs-viewer/`), you will be redirected to a default PDF file.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Redirecting...</title>
+  <meta http-equiv="refresh" content="0; url=./web/viewer.html?file=AI%E3%81%A7%E3%83%86%E3%83%BC%E3%83%9E%E3%82%BD%E3%83%B3%E3%82%B0.pdf">
+  <link rel="canonical" href="./web/viewer.html?file=AI%E3%81%A7%E3%83%86%E3%83%BC%E3%83%9E%E3%82%BD%E3%83%B3%E3%82%B0.pdf">
+</head>
+<body>
+  <p>If you are not redirected automatically, follow this <a href="./web/viewer.html?file=AI%E3%81%A7%E3%83%86%E3%83%BC%E3%83%9E%E3%82%BD%E3%83%B3%E3%82%B0.pdf">link to the PDF viewer</a>.</p>
+  <script>
+    window.location.replace('./web/viewer.html?file=AI%E3%81%A7%E3%83%86%E3%83%BC%E3%83%9E%E3%82%BD%E3%83%B3%E3%82%B0.pdf');
+  </script>
+</body>
+</html>


### PR DESCRIPTION
When accessing the root URL of the site, a 404 error was returned because no index.html was present. This change adds an index.html at the root of the repository that redirects the user to the PDF viewer in the `web/` directory, with a default file specified. This prevents the 404 error for the root URL.

This change also adds a README.md file with a brief description of the project and usage instructions.