### PR TITLE
slide-click.jsを修正し、PDFビューアのデフォルトのスクロールモードが意図せず単一ページ表示になる問題を解決しました。PDF…

### DIFF
--- a/web/slide-click.js
+++ b/web/slide-click.js
@@ -172,5 +172,15 @@
     if (!e.ctrlKey && !e.metaKey && !e.altKey && (e.key === 'f' || e.key === 'F')) { toggleFS(); e.preventDefault(); }
   }, true);
 
+  function setInitialScrollMode() {
+    if (STATE.enabled) return;
+    const v = viewer();
+    if (v) {
+      v.scrollMode = 0; // Vertical
+      v.currentScaleValue = 'auto';
+    }
+  }
+
+  document.addEventListener('pagesinit', setInitialScrollMode, { once: true });
   document.addEventListener('DOMContentLoaded', ensureUI);
 })();


### PR DESCRIPTION
…のメタデータによって単一ページレイアウトが指定された場合でも、スライド機能がオフのときは、ビューアが正しく垂直スクロールモードで初期化されるようにしました。