### PR TITLE
Hide PDF upload header after selecting a file

### DIFF
--- a/index.html
+++ b/index.html
@@ -154,8 +154,8 @@
       return file.name?.toLowerCase().endsWith('.pdf');
     }
 
-    function handleFileChange() {
-      const [file] = fileInput.files;
+    function handleFileChange(event) {
+      const [file] = event.target.files;
       if (!file) {
         return;
       }

--- a/index.html
+++ b/index.html
@@ -98,9 +98,27 @@
       }
     }
 
+    function isPdfFile(file) {
+      if (!file) {
+        return false;
+      }
+
+      if (file.type === 'application/pdf') {
+        return true;
+      }
+
+      return file.name?.toLowerCase().endsWith('.pdf');
+    }
+
     fileInput.addEventListener('change', () => {
       const [file] = fileInput.files;
       if (!file) {
+        return;
+      }
+
+      if (!isPdfFile(file)) {
+        status.textContent = 'PDFファイルを選択してください。';
+        fileInput.value = '';
         return;
       }
 

--- a/index.html
+++ b/index.html
@@ -78,8 +78,6 @@
 
   <script>
     const DEFAULT_PDF = './AIでテーマソング.pdf';
-    const VIEWER_PAGE_PATH = './web/viewer.html';
-
     const viewerFrame = document.getElementById('viewerFrame');
     const fileInput = document.getElementById('fileInput');
     const status = document.getElementById('status');
@@ -94,19 +92,16 @@
     let currentObjectUrl = null;
 
     function buildViewerUrl(fileUrl) {
-      return `${VIEWER_PAGE_PATH}?file=${encodeURIComponent(fileUrl)}`;
+      return `./web/viewer.html?file=${encodeURIComponent(fileUrl)}`;
     }
 
-    function updateViewerSource(fileUrl) {
+    function setViewerSource(fileUrl, message = STATUS_MESSAGES.default) {
       viewerFrame.src = buildViewerUrl(fileUrl);
-    }
-
-    function updateStatus(message = STATUS_MESSAGES.default) {
       status.textContent = message;
     }
 
-    function toggleHeaderVisibility(shouldHide) {
-      header.classList.toggle('is-hidden', shouldHide);
+    function setHeaderHidden(hidden) {
+      header.classList.toggle('is-hidden', hidden);
     }
 
     function clearFileSelection() {
@@ -123,22 +118,23 @@
     function showDefaultPdf() {
       revokeCurrentObjectUrl();
       clearFileSelection();
-      updateViewerSource(DEFAULT_PDF);
-      updateStatus();
-      toggleHeaderVisibility(false);
+      setViewerSource(DEFAULT_PDF);
+      setHeaderHidden(false);
     }
 
     function displayUploadedPdf(file) {
       revokeCurrentObjectUrl();
       currentObjectUrl = URL.createObjectURL(file);
-      updateViewerSource(currentObjectUrl);
-      updateStatus(`${file.name} を表示しています。${STATUS_MESSAGES.reloadHint}`);
-      toggleHeaderVisibility(true);
+      setViewerSource(
+        currentObjectUrl,
+        `${file.name} を表示しています。${STATUS_MESSAGES.reloadHint}`
+      );
+      setHeaderHidden(true);
     }
 
     function showInvalidFileMessage() {
-      updateStatus(STATUS_MESSAGES.invalid);
-      toggleHeaderVisibility(false);
+      status.textContent = STATUS_MESSAGES.invalid;
+      setHeaderHidden(false);
       clearFileSelection();
     }
 

--- a/index.html
+++ b/index.html
@@ -101,19 +101,19 @@
       viewerFrame.src = buildViewerUrl(fileUrl);
     }
 
-    function updateStatus(message = STATUS_MESSAGES.default) {
+    function setStatus(message = STATUS_MESSAGES.default) {
       status.textContent = message;
     }
 
-    function setHeaderVisibility(isHidden) {
-      header.classList.toggle('is-hidden', isHidden);
+    function toggleHeader(hidden) {
+      header.classList.toggle('is-hidden', hidden);
     }
 
     function clearFileInput() {
       fileInput.value = '';
     }
 
-    function resetObjectUrl() {
+    function releaseCurrentObjectUrl() {
       if (currentObjectUrl) {
         URL.revokeObjectURL(currentObjectUrl);
         currentObjectUrl = null;
@@ -121,24 +121,24 @@
     }
 
     function showDefaultPdf() {
-      resetObjectUrl();
+      releaseCurrentObjectUrl();
       clearFileInput();
       setViewerSource(DEFAULT_PDF);
-      updateStatus();
-      setHeaderVisibility(false);
+      setStatus();
+      toggleHeader(false);
     }
 
     function displayUploadedPdf(file) {
-      resetObjectUrl();
+      releaseCurrentObjectUrl();
       currentObjectUrl = URL.createObjectURL(file);
       setViewerSource(currentObjectUrl);
-      updateStatus(`${file.name} を表示しています。${STATUS_MESSAGES.reloadHint}`);
-      setHeaderVisibility(true);
+      setStatus(`${file.name} を表示しています。${STATUS_MESSAGES.reloadHint}`);
+      toggleHeader(true);
     }
 
-    function handleInvalidFile() {
-      updateStatus(STATUS_MESSAGES.invalidFile);
-      setHeaderVisibility(false);
+    function handleInvalidFileSelection() {
+      setStatus(STATUS_MESSAGES.invalidFile);
+      toggleHeader(false);
       clearFileInput();
     }
 
@@ -161,7 +161,7 @@
       }
 
       if (!isPdfFile(file)) {
-        handleInvalidFile();
+        handleInvalidFileSelection();
         return;
       }
 
@@ -169,8 +169,8 @@
     }
 
     fileInput.addEventListener('change', handleFileSelection);
-    window.addEventListener('beforeunload', resetObjectUrl);
-    window.addEventListener('pagehide', resetObjectUrl);
+    window.addEventListener('beforeunload', releaseCurrentObjectUrl);
+    window.addEventListener('pagehide', releaseCurrentObjectUrl);
 
     showDefaultPdf();
   </script>

--- a/index.html
+++ b/index.html
@@ -82,15 +82,28 @@
     const fileInput = document.getElementById('fileInput');
     const status = document.getElementById('status');
     const header = document.querySelector('header');
-    const DEFAULT_STATUS = 'サンプルPDFを表示しています。';
-    const RELOAD_HINT = '別のPDFを表示するにはページを再読み込みしてください。';
+
+    const STATUS_MESSAGES = {
+      default: 'サンプルPDFを表示しています。',
+      invalidFile: 'PDFファイルを選択してください。',
+      reloadHint: '別のPDFを表示するにはページを再読み込みしてください。'
+    };
 
     let currentObjectUrl = null;
 
-    function setViewerSource(url, description = DEFAULT_STATUS) {
+    function setViewerSource(url) {
       const viewerUrl = `./web/viewer.html?file=${encodeURIComponent(url)}`;
       viewerFrame.src = viewerUrl;
-      status.textContent = description;
+    }
+
+    function updateStatus(text) {
+      status.textContent = text;
+    }
+
+    function showDefaultPdf() {
+      setViewerSource(DEFAULT_PDF);
+      updateStatus(STATUS_MESSAGES.default);
+      header.classList.remove('is-hidden');
     }
 
     function resetObjectUrl() {
@@ -119,23 +132,22 @@
       }
 
       if (!isPdfFile(file)) {
-        status.textContent = 'PDFファイルを選択してください。';
+        updateStatus(STATUS_MESSAGES.invalidFile);
+        header.classList.remove('is-hidden');
         fileInput.value = '';
         return;
       }
 
       resetObjectUrl();
       currentObjectUrl = URL.createObjectURL(file);
-      setViewerSource(
-        currentObjectUrl,
-        `${file.name} を表示しています。${RELOAD_HINT}`
-      );
+      setViewerSource(currentObjectUrl);
+      updateStatus(`${file.name} を表示しています。${STATUS_MESSAGES.reloadHint}`);
       header.classList.add('is-hidden');
     });
 
     window.addEventListener('beforeunload', resetObjectUrl);
 
-    setViewerSource(DEFAULT_PDF);
+    showDefaultPdf();
   </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -91,13 +91,10 @@
 
     let currentObjectUrl = null;
 
-    function buildViewerUrl(fileUrl) {
-      return `./web/viewer.html?file=${encodeURIComponent(fileUrl)}`;
-    }
-
-    function setViewerSource(fileUrl, message = STATUS_MESSAGES.default) {
-      viewerFrame.src = buildViewerUrl(fileUrl);
-      status.textContent = message;
+    function setViewerSource(url, description) {
+      const viewerUrl = `./web/viewer.html?file=${encodeURIComponent(url)}`;
+      viewerFrame.src = viewerUrl;
+      status.textContent = description ?? STATUS_MESSAGES.default;
     }
 
     function setHeaderHidden(hidden) {
@@ -108,7 +105,7 @@
       fileInput.value = '';
     }
 
-    function revokeCurrentObjectUrl() {
+    function resetObjectUrl() {
       if (currentObjectUrl) {
         URL.revokeObjectURL(currentObjectUrl);
         currentObjectUrl = null;
@@ -116,14 +113,14 @@
     }
 
     function showDefaultPdf() {
-      revokeCurrentObjectUrl();
+      resetObjectUrl();
       clearFileSelection();
-      setViewerSource(DEFAULT_PDF);
+      setViewerSource(DEFAULT_PDF, STATUS_MESSAGES.default);
       setHeaderHidden(false);
     }
 
     function displayUploadedPdf(file) {
-      revokeCurrentObjectUrl();
+      resetObjectUrl();
       currentObjectUrl = URL.createObjectURL(file);
       setViewerSource(
         currentObjectUrl,
@@ -133,7 +130,7 @@
     }
 
     function showInvalidFileMessage() {
-      status.textContent = STATUS_MESSAGES.invalid;
+      setViewerSource(DEFAULT_PDF, STATUS_MESSAGES.invalid);
       setHeaderHidden(false);
       clearFileSelection();
     }
@@ -150,7 +147,7 @@
       return file.name?.toLowerCase().endsWith('.pdf');
     }
 
-    function handleFileChange(event) {
+    fileInput.addEventListener('change', (event) => {
       const [file] = event.target.files || [];
       if (!file) {
         return;
@@ -162,11 +159,10 @@
       }
 
       displayUploadedPdf(file);
-    }
+    });
 
-    fileInput.addEventListener('change', handleFileChange);
-    window.addEventListener('beforeunload', revokeCurrentObjectUrl);
-    window.addEventListener('pagehide', revokeCurrentObjectUrl);
+    window.addEventListener('beforeunload', resetObjectUrl);
+    window.addEventListener('pagehide', resetObjectUrl);
 
     showDefaultPdf();
   </script>

--- a/index.html
+++ b/index.html
@@ -78,6 +78,8 @@
 
   <script>
     const DEFAULT_PDF = './AIでテーマソング.pdf';
+    const PDF_VIEWER_BASE = './web/viewer.html';
+
     const viewerFrame = document.getElementById('viewerFrame');
     const fileInput = document.getElementById('fileInput');
     const status = document.getElementById('status');
@@ -91,13 +93,16 @@
 
     let currentObjectUrl = null;
 
-    function setViewerSource(url) {
-      const viewerUrl = `./web/viewer.html?file=${encodeURIComponent(url)}`;
-      viewerFrame.src = viewerUrl;
+    function buildViewerUrl(fileUrl) {
+      return `${PDF_VIEWER_BASE}?file=${encodeURIComponent(fileUrl)}`;
     }
 
-    function updateStatus(text) {
-      status.textContent = text;
+    function setViewerSource(fileUrl) {
+      viewerFrame.src = buildViewerUrl(fileUrl);
+    }
+
+    function updateStatus(message = STATUS_MESSAGES.default) {
+      status.textContent = message;
     }
 
     function clearFileInput() {
@@ -108,7 +113,7 @@
       resetObjectUrl();
       clearFileInput();
       setViewerSource(DEFAULT_PDF);
-      updateStatus(STATUS_MESSAGES.default);
+      updateStatus();
       header.classList.remove('is-hidden');
     }
 
@@ -118,6 +123,12 @@
       setViewerSource(currentObjectUrl);
       updateStatus(`${file.name} を表示しています。${STATUS_MESSAGES.reloadHint}`);
       header.classList.add('is-hidden');
+    }
+
+    function handleInvalidFile() {
+      updateStatus(STATUS_MESSAGES.invalidFile);
+      header.classList.remove('is-hidden');
+      clearFileInput();
     }
 
     function resetObjectUrl() {
@@ -139,23 +150,23 @@
       return file.name?.toLowerCase().endsWith('.pdf');
     }
 
-    fileInput.addEventListener('change', () => {
+    function handleFileSelection() {
       const [file] = fileInput.files;
       if (!file) {
         return;
       }
 
       if (!isPdfFile(file)) {
-        updateStatus(STATUS_MESSAGES.invalidFile);
-        header.classList.remove('is-hidden');
-        clearFileInput();
+        handleInvalidFile();
         return;
       }
 
       displayUploadedPdf(file);
-    });
+    }
 
+    fileInput.addEventListener('change', handleFileSelection);
     window.addEventListener('beforeunload', resetObjectUrl);
+    window.addEventListener('pagehide', resetObjectUrl);
 
     showDefaultPdf();
   </script>

--- a/index.html
+++ b/index.html
@@ -1,15 +1,118 @@
 <!DOCTYPE html>
-<html>
+<html lang="ja">
 <head>
   <meta charset="utf-8">
-  <title>Redirecting...</title>
-  <meta http-equiv="refresh" content="0; url=./web/viewer.html?file=AI%E3%81%A7%E3%83%86%E3%83%BC%E3%83%9E%E3%82%BD%E3%83%B3%E3%82%B0.pdf">
-  <link rel="canonical" href="./web/viewer.html?file=AI%E3%81%A7%E3%83%86%E3%83%BC%E3%83%9E%E3%82%BD%E3%83%B3%E3%82%B0.pdf">
+  <title>PDF Viewer</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    body {
+      margin: 0;
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      display: flex;
+      flex-direction: column;
+      min-height: 100vh;
+      background: #f5f5f5;
+    }
+
+    header {
+      background: #1a73e8;
+      color: white;
+      padding: 1rem 1.5rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+    }
+
+    header.is-hidden {
+      display: none;
+    }
+
+    header h1 {
+      margin: 0;
+      font-size: 1.5rem;
+      font-weight: 600;
+    }
+
+    #uploadControls {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 0.75rem;
+    }
+
+    #fileInput {
+      color: white;
+    }
+
+    #status {
+      font-size: 0.95rem;
+      opacity: 0.9;
+    }
+
+    main {
+      flex: 1;
+      display: flex;
+      min-height: 0;
+    }
+
+    #viewerFrame {
+      width: 100%;
+      border: none;
+      flex: 1;
+      min-height: 0;
+    }
+  </style>
 </head>
 <body>
-  <p>If you are not redirected automatically, follow this <a href="./web/viewer.html?file=AI%E3%81%A7%E3%83%86%E3%83%BC%E3%83%9E%E3%82%BD%E3%83%B3%E3%82%B0.pdf">link to the PDF viewer</a>.</p>
+  <header>
+    <h1>PDF表示</h1>
+    <div id="uploadControls">
+      <label for="fileInput">PDFファイルをアップロードして表示:</label>
+      <input id="fileInput" type="file" accept="application/pdf">
+    </div>
+    <div id="status">サンプルPDFを表示しています。</div>
+  </header>
+  <main>
+    <iframe id="viewerFrame" title="PDF viewer"></iframe>
+  </main>
+
   <script>
-    window.location.replace('./web/viewer.html?file=AI%E3%81%A7%E3%83%86%E3%83%BC%E3%83%9E%E3%82%BD%E3%83%B3%E3%82%B0.pdf');
+    const DEFAULT_PDF = './AIでテーマソング.pdf';
+    const viewerFrame = document.getElementById('viewerFrame');
+    const fileInput = document.getElementById('fileInput');
+    const status = document.getElementById('status');
+    const header = document.querySelector('header');
+
+    let currentObjectUrl = null;
+
+    function setViewerSource(url, description) {
+      const viewerUrl = `./web/viewer.html?file=${encodeURIComponent(url)}`;
+      viewerFrame.src = viewerUrl;
+      status.textContent = description;
+    }
+
+    function resetObjectUrl() {
+      if (currentObjectUrl) {
+        URL.revokeObjectURL(currentObjectUrl);
+        currentObjectUrl = null;
+      }
+    }
+
+    fileInput.addEventListener('change', () => {
+      const [file] = fileInput.files;
+      if (!file) {
+        return;
+      }
+
+      resetObjectUrl();
+      currentObjectUrl = URL.createObjectURL(file);
+      setViewerSource(currentObjectUrl, `${file.name} を表示しています。`);
+      header.classList.add('is-hidden');
+    });
+
+    window.addEventListener('beforeunload', resetObjectUrl);
+
+    setViewerSource(DEFAULT_PDF, 'サンプルPDFを表示しています。');
   </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -97,16 +97,16 @@
       return `${VIEWER_PAGE_PATH}?file=${encodeURIComponent(fileUrl)}`;
     }
 
-    function setViewerSource(fileUrl) {
+    function updateViewerSource(fileUrl) {
       viewerFrame.src = buildViewerUrl(fileUrl);
     }
 
-    function setStatus(message = STATUS_MESSAGES.default) {
+    function updateStatus(message = STATUS_MESSAGES.default) {
       status.textContent = message;
     }
 
-    function setHeaderHidden(hidden) {
-      header.classList.toggle('is-hidden', hidden);
+    function toggleHeaderVisibility(shouldHide) {
+      header.classList.toggle('is-hidden', shouldHide);
     }
 
     function clearFileSelection() {
@@ -123,22 +123,22 @@
     function showDefaultPdf() {
       revokeCurrentObjectUrl();
       clearFileSelection();
-      setViewerSource(DEFAULT_PDF);
-      setStatus();
-      setHeaderHidden(false);
+      updateViewerSource(DEFAULT_PDF);
+      updateStatus();
+      toggleHeaderVisibility(false);
     }
 
     function displayUploadedPdf(file) {
       revokeCurrentObjectUrl();
       currentObjectUrl = URL.createObjectURL(file);
-      setViewerSource(currentObjectUrl);
-      setStatus(`${file.name} を表示しています。${STATUS_MESSAGES.reloadHint}`);
-      setHeaderHidden(true);
+      updateViewerSource(currentObjectUrl);
+      updateStatus(`${file.name} を表示しています。${STATUS_MESSAGES.reloadHint}`);
+      toggleHeaderVisibility(true);
     }
 
     function showInvalidFileMessage() {
-      setStatus(STATUS_MESSAGES.invalid);
-      setHeaderHidden(false);
+      updateStatus(STATUS_MESSAGES.invalid);
+      toggleHeaderVisibility(false);
       clearFileSelection();
     }
 
@@ -155,7 +155,7 @@
     }
 
     function handleFileChange(event) {
-      const [file] = event.target.files;
+      const [file] = event.target.files || [];
       if (!file) {
         return;
       }

--- a/index.html
+++ b/index.html
@@ -101,9 +101,18 @@
     }
 
     function showDefaultPdf() {
+      resetObjectUrl();
       setViewerSource(DEFAULT_PDF);
       updateStatus(STATUS_MESSAGES.default);
       header.classList.remove('is-hidden');
+    }
+
+    function displayUploadedPdf(file) {
+      resetObjectUrl();
+      currentObjectUrl = URL.createObjectURL(file);
+      setViewerSource(currentObjectUrl);
+      updateStatus(`${file.name} を表示しています。${STATUS_MESSAGES.reloadHint}`);
+      header.classList.add('is-hidden');
     }
 
     function resetObjectUrl() {
@@ -138,11 +147,7 @@
         return;
       }
 
-      resetObjectUrl();
-      currentObjectUrl = URL.createObjectURL(file);
-      setViewerSource(currentObjectUrl);
-      updateStatus(`${file.name} を表示しています。${STATUS_MESSAGES.reloadHint}`);
-      header.classList.add('is-hidden');
+      displayUploadedPdf(file);
     });
 
     window.addEventListener('beforeunload', resetObjectUrl);

--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@
 
   <script>
     const DEFAULT_PDF = './AIでテーマソング.pdf';
-    const PDF_VIEWER_PATH = './web/viewer.html';
+    const VIEWER_PAGE_PATH = './web/viewer.html';
 
     const viewerFrame = document.getElementById('viewerFrame');
     const fileInput = document.getElementById('fileInput');
@@ -94,22 +94,22 @@
     let currentObjectUrl = null;
 
     function buildViewerUrl(fileUrl) {
-      return `${PDF_VIEWER_PATH}?file=${encodeURIComponent(fileUrl)}`;
+      return `${VIEWER_PAGE_PATH}?file=${encodeURIComponent(fileUrl)}`;
     }
 
-    function updateViewerSource(fileUrl) {
+    function setViewerSource(fileUrl) {
       viewerFrame.src = buildViewerUrl(fileUrl);
     }
 
-    function updateStatus(message = STATUS_MESSAGES.default) {
+    function setStatus(message = STATUS_MESSAGES.default) {
       status.textContent = message;
     }
 
-    function setHeaderHidden(isHidden) {
-      header.classList.toggle('is-hidden', isHidden);
+    function setHeaderHidden(hidden) {
+      header.classList.toggle('is-hidden', hidden);
     }
 
-    function clearSelectedFile() {
+    function clearFileSelection() {
       fileInput.value = '';
     }
 
@@ -122,24 +122,24 @@
 
     function showDefaultPdf() {
       revokeCurrentObjectUrl();
-      clearSelectedFile();
-      updateViewerSource(DEFAULT_PDF);
-      updateStatus();
+      clearFileSelection();
+      setViewerSource(DEFAULT_PDF);
+      setStatus();
       setHeaderHidden(false);
     }
 
     function displayUploadedPdf(file) {
       revokeCurrentObjectUrl();
       currentObjectUrl = URL.createObjectURL(file);
-      updateViewerSource(currentObjectUrl);
-      updateStatus(`${file.name} を表示しています。${STATUS_MESSAGES.reloadHint}`);
+      setViewerSource(currentObjectUrl);
+      setStatus(`${file.name} を表示しています。${STATUS_MESSAGES.reloadHint}`);
       setHeaderHidden(true);
     }
 
-    function handleInvalidSelection() {
-      updateStatus(STATUS_MESSAGES.invalid);
+    function showInvalidFileMessage() {
+      setStatus(STATUS_MESSAGES.invalid);
       setHeaderHidden(false);
-      clearSelectedFile();
+      clearFileSelection();
     }
 
     function isPdfFile(file) {
@@ -161,7 +161,7 @@
       }
 
       if (!isPdfFile(file)) {
-        handleInvalidSelection();
+        showInvalidFileMessage();
         return;
       }
 

--- a/index.html
+++ b/index.html
@@ -100,8 +100,13 @@
       status.textContent = text;
     }
 
+    function clearFileInput() {
+      fileInput.value = '';
+    }
+
     function showDefaultPdf() {
       resetObjectUrl();
+      clearFileInput();
       setViewerSource(DEFAULT_PDF);
       updateStatus(STATUS_MESSAGES.default);
       header.classList.remove('is-hidden');
@@ -143,7 +148,7 @@
       if (!isPdfFile(file)) {
         updateStatus(STATUS_MESSAGES.invalidFile);
         header.classList.remove('is-hidden');
-        fileInput.value = '';
+        clearFileInput();
         return;
       }
 

--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@
       <label for="fileInput">PDFファイルをアップロードして表示:</label>
       <input id="fileInput" type="file" accept="application/pdf">
     </div>
-    <div id="status">サンプルPDFを表示しています。</div>
+    <div id="status" role="status" aria-live="polite">サンプルPDFを表示しています。</div>
   </header>
   <main>
     <iframe id="viewerFrame" title="PDF viewer"></iframe>
@@ -105,6 +105,10 @@
       status.textContent = message;
     }
 
+    function setHeaderVisibility(isHidden) {
+      header.classList.toggle('is-hidden', isHidden);
+    }
+
     function clearFileInput() {
       fileInput.value = '';
     }
@@ -121,7 +125,7 @@
       clearFileInput();
       setViewerSource(DEFAULT_PDF);
       updateStatus();
-      header.classList.remove('is-hidden');
+      setHeaderVisibility(false);
     }
 
     function displayUploadedPdf(file) {
@@ -129,12 +133,12 @@
       currentObjectUrl = URL.createObjectURL(file);
       setViewerSource(currentObjectUrl);
       updateStatus(`${file.name} を表示しています。${STATUS_MESSAGES.reloadHint}`);
-      header.classList.add('is-hidden');
+      setHeaderVisibility(true);
     }
 
     function handleInvalidFile() {
       updateStatus(STATUS_MESSAGES.invalidFile);
-      header.classList.remove('is-hidden');
+      setHeaderVisibility(false);
       clearFileInput();
     }
 

--- a/index.html
+++ b/index.html
@@ -82,10 +82,12 @@
     const fileInput = document.getElementById('fileInput');
     const status = document.getElementById('status');
     const header = document.querySelector('header');
+    const DEFAULT_STATUS = 'サンプルPDFを表示しています。';
+    const RELOAD_HINT = '別のPDFを表示するにはページを再読み込みしてください。';
 
     let currentObjectUrl = null;
 
-    function setViewerSource(url, description) {
+    function setViewerSource(url, description = DEFAULT_STATUS) {
       const viewerUrl = `./web/viewer.html?file=${encodeURIComponent(url)}`;
       viewerFrame.src = viewerUrl;
       status.textContent = description;
@@ -124,13 +126,16 @@
 
       resetObjectUrl();
       currentObjectUrl = URL.createObjectURL(file);
-      setViewerSource(currentObjectUrl, `${file.name} を表示しています。`);
+      setViewerSource(
+        currentObjectUrl,
+        `${file.name} を表示しています。${RELOAD_HINT}`
+      );
       header.classList.add('is-hidden');
     });
 
     window.addEventListener('beforeunload', resetObjectUrl);
 
-    setViewerSource(DEFAULT_PDF, 'サンプルPDFを表示しています。');
+    setViewerSource(DEFAULT_PDF);
   </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@
 
   <script>
     const DEFAULT_PDF = './AIでテーマソング.pdf';
-    const VIEWER_BASE = './web/viewer.html';
+    const PDF_VIEWER_PATH = './web/viewer.html';
 
     const viewerFrame = document.getElementById('viewerFrame');
     const fileInput = document.getElementById('fileInput');
@@ -94,26 +94,26 @@
     let currentObjectUrl = null;
 
     function buildViewerUrl(fileUrl) {
-      return `${VIEWER_BASE}?file=${encodeURIComponent(fileUrl)}`;
+      return `${PDF_VIEWER_PATH}?file=${encodeURIComponent(fileUrl)}`;
     }
 
-    function setViewerSource(fileUrl) {
+    function updateViewerSource(fileUrl) {
       viewerFrame.src = buildViewerUrl(fileUrl);
     }
 
-    function setStatus(message = STATUS_MESSAGES.default) {
+    function updateStatus(message = STATUS_MESSAGES.default) {
       status.textContent = message;
     }
 
-    function toggleHeader(isHidden) {
+    function setHeaderHidden(isHidden) {
       header.classList.toggle('is-hidden', isHidden);
     }
 
-    function clearFileSelection() {
+    function clearSelectedFile() {
       fileInput.value = '';
     }
 
-    function releaseObjectUrl() {
+    function revokeCurrentObjectUrl() {
       if (currentObjectUrl) {
         URL.revokeObjectURL(currentObjectUrl);
         currentObjectUrl = null;
@@ -121,25 +121,25 @@
     }
 
     function showDefaultPdf() {
-      releaseObjectUrl();
-      clearFileSelection();
-      setViewerSource(DEFAULT_PDF);
-      setStatus();
-      toggleHeader(false);
+      revokeCurrentObjectUrl();
+      clearSelectedFile();
+      updateViewerSource(DEFAULT_PDF);
+      updateStatus();
+      setHeaderHidden(false);
     }
 
     function displayUploadedPdf(file) {
-      releaseObjectUrl();
+      revokeCurrentObjectUrl();
       currentObjectUrl = URL.createObjectURL(file);
-      setViewerSource(currentObjectUrl);
-      setStatus(`${file.name} を表示しています。${STATUS_MESSAGES.reloadHint}`);
-      toggleHeader(true);
+      updateViewerSource(currentObjectUrl);
+      updateStatus(`${file.name} を表示しています。${STATUS_MESSAGES.reloadHint}`);
+      setHeaderHidden(true);
     }
 
     function handleInvalidSelection() {
-      setStatus(STATUS_MESSAGES.invalid);
-      toggleHeader(false);
-      clearFileSelection();
+      updateStatus(STATUS_MESSAGES.invalid);
+      setHeaderHidden(false);
+      clearSelectedFile();
     }
 
     function isPdfFile(file) {
@@ -154,7 +154,7 @@
       return file.name?.toLowerCase().endsWith('.pdf');
     }
 
-    function handleFileSelection() {
+    function handleFileChange() {
       const [file] = fileInput.files;
       if (!file) {
         return;
@@ -168,9 +168,9 @@
       displayUploadedPdf(file);
     }
 
-    fileInput.addEventListener('change', handleFileSelection);
-    window.addEventListener('beforeunload', releaseObjectUrl);
-    window.addEventListener('pagehide', releaseObjectUrl);
+    fileInput.addEventListener('change', handleFileChange);
+    window.addEventListener('beforeunload', revokeCurrentObjectUrl);
+    window.addEventListener('pagehide', revokeCurrentObjectUrl);
 
     showDefaultPdf();
   </script>

--- a/index.html
+++ b/index.html
@@ -78,23 +78,23 @@
 
   <script>
     const DEFAULT_PDF = './AIでテーマソング.pdf';
-    const PDF_VIEWER_BASE = './web/viewer.html';
+    const VIEWER_BASE = './web/viewer.html';
 
     const viewerFrame = document.getElementById('viewerFrame');
     const fileInput = document.getElementById('fileInput');
     const status = document.getElementById('status');
     const header = document.querySelector('header');
 
-    const STATUS_MESSAGES = {
+    const STATUS_MESSAGES = Object.freeze({
       default: 'サンプルPDFを表示しています。',
-      invalidFile: 'PDFファイルを選択してください。',
+      invalid: 'PDFファイルを選択してください。',
       reloadHint: '別のPDFを表示するにはページを再読み込みしてください。'
-    };
+    });
 
     let currentObjectUrl = null;
 
     function buildViewerUrl(fileUrl) {
-      return `${PDF_VIEWER_BASE}?file=${encodeURIComponent(fileUrl)}`;
+      return `${VIEWER_BASE}?file=${encodeURIComponent(fileUrl)}`;
     }
 
     function setViewerSource(fileUrl) {
@@ -105,15 +105,15 @@
       status.textContent = message;
     }
 
-    function toggleHeader(hidden) {
-      header.classList.toggle('is-hidden', hidden);
+    function toggleHeader(isHidden) {
+      header.classList.toggle('is-hidden', isHidden);
     }
 
-    function clearFileInput() {
+    function clearFileSelection() {
       fileInput.value = '';
     }
 
-    function releaseCurrentObjectUrl() {
+    function releaseObjectUrl() {
       if (currentObjectUrl) {
         URL.revokeObjectURL(currentObjectUrl);
         currentObjectUrl = null;
@@ -121,25 +121,25 @@
     }
 
     function showDefaultPdf() {
-      releaseCurrentObjectUrl();
-      clearFileInput();
+      releaseObjectUrl();
+      clearFileSelection();
       setViewerSource(DEFAULT_PDF);
       setStatus();
       toggleHeader(false);
     }
 
     function displayUploadedPdf(file) {
-      releaseCurrentObjectUrl();
+      releaseObjectUrl();
       currentObjectUrl = URL.createObjectURL(file);
       setViewerSource(currentObjectUrl);
       setStatus(`${file.name} を表示しています。${STATUS_MESSAGES.reloadHint}`);
       toggleHeader(true);
     }
 
-    function handleInvalidFileSelection() {
-      setStatus(STATUS_MESSAGES.invalidFile);
+    function handleInvalidSelection() {
+      setStatus(STATUS_MESSAGES.invalid);
       toggleHeader(false);
-      clearFileInput();
+      clearFileSelection();
     }
 
     function isPdfFile(file) {
@@ -161,7 +161,7 @@
       }
 
       if (!isPdfFile(file)) {
-        handleInvalidFileSelection();
+        handleInvalidSelection();
         return;
       }
 
@@ -169,8 +169,8 @@
     }
 
     fileInput.addEventListener('change', handleFileSelection);
-    window.addEventListener('beforeunload', releaseCurrentObjectUrl);
-    window.addEventListener('pagehide', releaseCurrentObjectUrl);
+    window.addEventListener('beforeunload', releaseObjectUrl);
+    window.addEventListener('pagehide', releaseObjectUrl);
 
     showDefaultPdf();
   </script>

--- a/index.html
+++ b/index.html
@@ -109,6 +109,13 @@
       fileInput.value = '';
     }
 
+    function resetObjectUrl() {
+      if (currentObjectUrl) {
+        URL.revokeObjectURL(currentObjectUrl);
+        currentObjectUrl = null;
+      }
+    }
+
     function showDefaultPdf() {
       resetObjectUrl();
       clearFileInput();
@@ -129,13 +136,6 @@
       updateStatus(STATUS_MESSAGES.invalidFile);
       header.classList.remove('is-hidden');
       clearFileInput();
-    }
-
-    function resetObjectUrl() {
-      if (currentObjectUrl) {
-        URL.revokeObjectURL(currentObjectUrl);
-        currentObjectUrl = null;
-      }
     }
 
     function isPdfFile(file) {


### PR DESCRIPTION
## Summary
- replace the redirect-only landing page with an embedded PDF viewer
- add styling and controls to upload a PDF from the browser and display it in the existing viewer
- keep a default sample PDF visible while no upload is selected and manage object URLs safely
- hide the upload header once a PDF is selected to maximize the viewer area

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68eccc8a76b88320ba9db7595165d531