### PR TITLE
feat: Hide PDF viewer toolbar on file upload

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
     let currentObjectUrl = null;
 
     function setViewerSource(url, description) {
-      const viewerUrl = `./web/viewer.html?file=${encodeURIComponent(url)}`;
+      const viewerUrl = `./web/viewer.html?file=${encodeURIComponent(url)}#toolbar=0`;
       viewerFrame.src = viewerUrl;
       status.textContent = description;
     }


### PR DESCRIPTION
This change hides the toolbar of the PDF.js viewer when a user uploads a PDF file. This is achieved by appending the '#toolbar=0' hash parameter to the viewer's URL in the 'setViewerSource' function in index.html.