### PR TITLE
Hide upload header after selecting a PDF

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,6 +45,10 @@
       opacity: 0.9;
     }
 
+    .is-hidden {
+      display: none !important;
+    }
+
     main {
       flex: 1;
       display: flex;
@@ -77,6 +81,7 @@
     const viewerFrame = document.getElementById('viewerFrame');
     const fileInput = document.getElementById('fileInput');
     const status = document.getElementById('status');
+    const header = document.querySelector('header');
 
     let currentObjectUrl = null;
 
@@ -102,6 +107,7 @@
       resetObjectUrl();
       currentObjectUrl = URL.createObjectURL(file);
       setViewerSource(currentObjectUrl, `${file.name} を表示しています。`);
+      header.classList.add('is-hidden');
     });
 
     window.addEventListener('beforeunload', resetObjectUrl);


### PR DESCRIPTION
## Summary
- hide the blue header once a user uploads a PDF so it no longer covers the viewer
- add a utility class that collapses the header when applied

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68ed2e903d908320910eebed9b3ee7fc