### PR TITLE
Hide PDF viewer toolbar after uploading a file

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -5916,6 +5916,20 @@ body.wait::before{
   z-index:2;
 }
 
+/* === Customizations: hide the built-in toolbar when body.hideToolbar is present === */
+body.hideToolbar{
+  --toolbar-height:0px;
+}
+
+body.hideToolbar .toolbar,
+body.hideToolbar #loadingBar{
+  display:none !important;
+}
+
+body.hideToolbar #viewerContainer{
+  inset:0 0 0 !important;
+}
+
 #toolbarSidebar{
   width:100%;
   height:var(--toolbar-height);

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -36,7 +36,7 @@ See https://github.com/adobe-type-tools/cmap-resources
   <script src="viewer.mjs" type="module"></script>
   </head>
 
-  <body tabindex="0">
+  <body tabindex="0" class="hideToolbar">
     <div id="outerContainer">
       <span id="viewer-alert" class="visuallyHidden" role="alert"></span>
 


### PR DESCRIPTION
## Summary
- apply a dedicated class to the embedded PDF.js viewer so the built-in toolbar is hidden
- adjust the viewer CSS so the document area expands to fill the space where the toolbar was shown

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68ed30b9040c8320b14b6f3af6ab21d4