### PR TITLE
Link README license section to LICENSE file

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,5 +40,5 @@ https://tarosay.github.io/pdfs-viewer/web/viewer.html?file=ラズパイとiPhone
 
 ## License
 
-This project is licensed under the **MIT License**.
+This project is licensed under the [**MIT License**](LICENSE).
 


### PR DESCRIPTION
## Summary
- add a markdown link from the README license section to the LICENSE file

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68edd6a2f34083208ce99148229e9d0e