### PR TITLE
Ensure mikankame mascot renders in fullscreen mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,6 +126,7 @@
   <script>
     const DEFAULT_PDF = './pdffileviewer.pdf';
     const MASCOT_ANIMATION_DURATION_MS = 8000;
+    const MIKANKAME_HIDE_STORAGE_KEY = 'mikankameHidden';
     const viewerFrame = document.getElementById('viewerFrame');
     const fileInput = document.getElementById('fileInput');
     const status = document.getElementById('status');
@@ -136,6 +137,45 @@
     let currentObjectUrl = null;
     let dropZoneDepth = 0;
 
+    function postMessageToViewer(data) {
+      try {
+        viewerFrame.contentWindow?.postMessage(data, '*');
+      } catch (error) {
+        console.warn('Failed to communicate with the embedded viewer.', error);
+      }
+    }
+
+    function requestViewerMascotAnimation() {
+      postMessageToViewer({ type: 'play-mikankame-animation' });
+    }
+
+    function notifyViewerAboutMascotVisibility() {
+      postMessageToViewer({ type: 'update-mikankame-visibility' });
+    }
+
+    function shouldHideMascot() {
+      try {
+        return localStorage.getItem(MIKANKAME_HIDE_STORAGE_KEY) === 'true';
+      } catch (error) {
+        console.warn('Failed to access mikankame preference from localStorage.', error);
+        return false;
+      }
+    }
+
+    function updateMascotVisibility() {
+      if (!mascot) {
+        return;
+      }
+
+      const shouldHide = shouldHideMascot();
+      mascot.classList.toggle('is-hidden', shouldHide);
+      if (shouldHide) {
+        mascot.classList.remove('is-animating');
+      }
+
+      notifyViewerAboutMascotVisibility();
+    }
+
     function setViewerSource(url, description) {
       const viewerUrl = `./web/viewer.html?file=${encodeURIComponent(url)}#toolbar=0`;
       viewerFrame.src = viewerUrl;
@@ -144,7 +184,7 @@
     }
 
     function playMascotAnimation() {
-      if (!mascot) {
+      if (!mascot || shouldHideMascot()) {
         return;
       }
 
@@ -153,6 +193,8 @@
       // Force reflow so that removing the class allows the animation to restart.
       void mascot.offsetWidth;
       mascot.classList.add('is-animating');
+
+      requestViewerMascotAnimation();
     }
 
     function loadPdfFile(file) {
@@ -256,6 +298,17 @@
 
     window.addEventListener('beforeunload', resetObjectUrl);
 
+    document.addEventListener('fullscreenchange', () => {
+      if (document.fullscreenElement === viewerFrame && !shouldHideMascot()) {
+        requestViewerMascotAnimation();
+      }
+    });
+
+    viewerFrame.addEventListener('load', () => {
+      notifyViewerAboutMascotVisibility();
+    });
+
+    updateMascotVisibility();
     setViewerSource(DEFAULT_PDF, 'サンプルPDFを表示しています。');
   </script>
 </body>

--- a/web/mikankame_overlay.js
+++ b/web/mikankame_overlay.js
@@ -1,0 +1,107 @@
+const MASCOT_ANIMATION_DURATION_MS = 8000;
+const MIKANKAME_HIDE_STORAGE_KEY = "mikankameHidden";
+const mascotElement = document.getElementById("mikankameOverlay");
+
+if (mascotElement) {
+  const isEmbeddedViewer = window.top !== window;
+
+  const fullScreenEvents = [
+    "fullscreenchange",
+    "webkitfullscreenchange",
+    "msfullscreenchange",
+  ];
+
+  function isDocumentFullscreen() {
+    return Boolean(
+      document.fullscreenElement ||
+        document.webkitFullscreenElement ||
+        document.msFullscreenElement
+    );
+  }
+
+  function shouldHideFromSetting() {
+    try {
+      return localStorage.getItem(MIKANKAME_HIDE_STORAGE_KEY) === "true";
+    } catch (error) {
+      console.warn(
+        "Failed to access mikankame preference from localStorage inside the viewer.",
+        error,
+      );
+      return false;
+    }
+  }
+
+  function shouldDisplayMascot() {
+    if (shouldHideFromSetting()) {
+      return false;
+    }
+
+    if (!isEmbeddedViewer) {
+      return true;
+    }
+
+    return isDocumentFullscreen();
+  }
+
+  function updateMascotVisibility() {
+    const shouldShow = shouldDisplayMascot();
+    mascotElement.classList.toggle("pdfs-mikankame-hidden", !shouldShow);
+    mascotElement.classList.toggle("pdfs-mikankame-visible", shouldShow);
+
+    if (!shouldShow) {
+      mascotElement.classList.remove("pdfs-mikankame-animating");
+    }
+  }
+
+  function playMascotAnimation() {
+    if (!shouldDisplayMascot()) {
+      return;
+    }
+
+    mascotElement.style.setProperty(
+      "--mascot-duration",
+      `${MASCOT_ANIMATION_DURATION_MS}ms`,
+    );
+    mascotElement.classList.remove("pdfs-mikankame-hidden");
+    mascotElement.classList.add("pdfs-mikankame-visible");
+    mascotElement.classList.remove("pdfs-mikankame-animating");
+    void mascotElement.offsetWidth;
+    mascotElement.classList.add("pdfs-mikankame-animating");
+  }
+
+  function handleMessage(event) {
+    const { data } = event;
+    if (!data || typeof data !== "object") {
+      return;
+    }
+
+    switch (data.type) {
+      case "play-mikankame-animation":
+        playMascotAnimation();
+        break;
+      case "update-mikankame-visibility":
+        updateMascotVisibility();
+        break;
+      default:
+        break;
+    }
+  }
+
+  document.addEventListener("DOMContentLoaded", () => {
+    updateMascotVisibility();
+    if (!isEmbeddedViewer) {
+      playMascotAnimation();
+    }
+  });
+
+  window.addEventListener("message", handleMessage);
+  window.addEventListener("storage", updateMascotVisibility);
+  fullScreenEvents.forEach((eventName) => {
+    document.addEventListener(eventName, updateMascotVisibility);
+    document.addEventListener(eventName, () => {
+      if (isDocumentFullscreen()) {
+        playMascotAnimation();
+      }
+    });
+  });
+}

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -7277,6 +7277,42 @@ dialog :link{
   }
 }
 
+#mikankameOverlay {
+  position: fixed;
+  left: 16px;
+  bottom: 16px;
+  width: min(140px, 25vw);
+  max-width: 40vw;
+  pointer-events: none;
+  transform: translateX(0);
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  z-index: 2147483647;
+}
+
+#mikankameOverlay.pdfs-mikankame-visible {
+  opacity: 1;
+}
+
+#mikankameOverlay.pdfs-mikankame-animating {
+  animation: pdfsMascotSlideAcross var(--mascot-duration, 6s) ease-in-out forwards;
+  opacity: 1;
+}
+
+#mikankameOverlay.pdfs-mikankame-hidden {
+  display: none !important;
+}
+
+@keyframes pdfsMascotSlideAcross {
+  from {
+    transform: translateX(0);
+  }
+
+  to {
+    transform: translateX(calc(100vw - 100% - 32px));
+  }
+}
+
 @media all and (max-width: 690px){
   .hiddenSmallView,
   .hiddenSmallView *{

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -783,6 +783,12 @@ See https://github.com/adobe-type-tools/cmap-resources
 
     </div> <!-- outerContainer -->
     <div id="printContainer"></div>
+    <img
+      id="mikankameOverlay"
+      src="../mikankame.png"
+      alt="みかんとカメのイラスト"
+    />
     <script src="slide-click.js"></script>
+    <script src="mikankame_overlay.js" type="module"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- keep the landing page mascot visibility in sync with the embedded viewer and respect the hide setting
- add a fullscreen-aware mikankame overlay script inside the viewer so the mascot appears during presentation mode or standalone use
- style the viewer overlay so the mascot animates consistently across modes

## Testing
- Not run (static site)


------
https://chatgpt.com/codex/tasks/task_b_68efe1c619ac8320b89be0c392611799