### PR TITLE
Prevent mascot animation restart on fullscreen toggles

### DIFF
--- a/web/mikankame_overlay.js
+++ b/web/mikankame_overlay.js
@@ -58,6 +58,10 @@ if (mascotElement) {
     }
   }
 
+  function isMascotAnimating() {
+    return mascotElement.classList.contains("pdfs-mikankame-animating");
+  }
+
   function playMascotAnimation() {
     if (!shouldDisplayMascot()) {
       return;
@@ -104,6 +108,18 @@ if (mascotElement) {
     }
   }
 
+  function handleFullscreenChange() {
+    updateMascotVisibility();
+
+    if (
+      isDocumentFullscreen() &&
+      !hasCompletedMascotAnimation &&
+      !isMascotAnimating()
+    ) {
+      playMascotAnimation();
+    }
+  }
+
   document.addEventListener("DOMContentLoaded", () => {
     updateMascotVisibility();
     if (!isEmbeddedViewer) {
@@ -115,11 +131,6 @@ if (mascotElement) {
   window.addEventListener("storage", updateMascotVisibility);
   mascotElement.addEventListener("animationend", handleAnimationEnd);
   fullScreenEvents.forEach((eventName) => {
-    document.addEventListener(eventName, updateMascotVisibility);
-    document.addEventListener(eventName, () => {
-      if (isDocumentFullscreen()) {
-        playMascotAnimation();
-      }
-    });
+    document.addEventListener(eventName, handleFullscreenChange);
   });
 }


### PR DESCRIPTION
## Summary
- add a guard that only replays the mascot animation on fullscreen when it has not completed yet
- centralize fullscreen change handling so visibility updates still run without resetting the mascot position

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68efe88b3e948320b7e67ec57c0185be