### PR TITLE
Prevent mascot re-animation on fullscreen toggle

### DIFF
--- a/web/mikankame_overlay.js
+++ b/web/mikankame_overlay.js
@@ -63,7 +63,11 @@ if (mascotElement) {
   }
 
   function playMascotAnimation() {
-    if (!shouldDisplayMascot()) {
+    if (
+      !shouldDisplayMascot() ||
+      hasCompletedMascotAnimation ||
+      isMascotAnimating()
+    ) {
       return;
     }
 


### PR DESCRIPTION
## Summary
- stop the Mikankame overlay from replaying its entrance animation after it has already completed once
- ignore repeated animation requests while the mascot is animating or finished so fullscreen toggles no longer reset its position

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_b_68efea6551ec83208fad32fe3c2e1b6c