### PR TITLE
Avoid resetting mascot position on fullscreen

### DIFF
--- a/web/mikankame_overlay.js
+++ b/web/mikankame_overlay.js
@@ -1,6 +1,7 @@
 const MASCOT_ANIMATION_DURATION_MS = 8000;
 const MASCOT_FINAL_TRANSFORM = "translateX(calc(100vw - 100% - 32px))";
 let hasCompletedMascotAnimation = false;
+let hasResetMascotPositionSinceLoad = false;
 const MIKANKAME_HIDE_STORAGE_KEY = "mikankameHidden";
 const mascotElement = document.getElementById("mikankameOverlay");
 
@@ -72,7 +73,10 @@ if (mascotElement) {
     }
 
     hasCompletedMascotAnimation = false;
-    mascotElement.style.removeProperty("transform");
+    if (!hasResetMascotPositionSinceLoad) {
+      mascotElement.style.removeProperty("transform");
+      hasResetMascotPositionSinceLoad = true;
+    }
     mascotElement.style.setProperty(
       "--mascot-duration",
       `${MASCOT_ANIMATION_DURATION_MS}ms`,


### PR DESCRIPTION
## Summary
- prevent the fullscreen toggle from repeatedly resetting the Mikankame mascot to the starting position
- track whether the mascot position has already been reset during the current viewer load before clearing transforms

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68efec14380483208b6d281f0290ef93