### PR TITLE
Add control to configure mascot slide duration

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,6 +38,35 @@
       gap: 0.75rem;
     }
 
+    #mascotControls {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 0.5rem;
+      color: rgba(255, 255, 255, 0.9);
+      font-size: 0.9rem;
+    }
+
+    #mascotDurationInput {
+      width: 6rem;
+      padding: 0.25rem 0.5rem;
+      border-radius: 6px;
+      border: 1px solid rgba(255, 255, 255, 0.6);
+      background: rgba(0, 0, 0, 0.15);
+      color: #fff;
+      font-size: 0.95rem;
+    }
+
+    #mascotDurationInput:focus {
+      outline: 2px solid rgba(255, 255, 255, 0.7);
+      outline-offset: 1px;
+    }
+
+    #mascotDurationSummary {
+      font-size: 0.85rem;
+      opacity: 0.85;
+    }
+
     #fileInput {
       color: white;
     }
@@ -88,6 +117,18 @@
       <label for="fileInput">PDFファイルをアップロードして表示:</label>
       <input id="fileInput" type="file" accept="application/pdf">
     </div>
+    <div id="mascotControls">
+      <label for="mascotDurationInput">ミカンカメの移動時間 (分):</label>
+      <input
+        id="mascotDurationInput"
+        type="number"
+        min="0.1"
+        step="0.01"
+        inputmode="decimal"
+        aria-describedby="mascotDurationSummary"
+      >
+      <span id="mascotDurationSummary"></span>
+    </div>
     <div id="headerDropZone">青いヘッダーの空いている場所にPDFをドラッグ＆ドロップできます。</div>
     <div id="status">サンプルPDFを表示しています。</div>
   </header>
@@ -98,11 +139,15 @@
   <script>
     const DEFAULT_PDF = './pdffileviewer.pdf';
     const MIKANKAME_HIDE_STORAGE_KEY = 'mikankameHidden';
+    const MIKANKAME_DURATION_STORAGE_KEY = 'mikankameDurationMinutes';
+    const DEFAULT_MASCOT_DURATION_MINUTES = 8 / 60;
     const viewerFrame = document.getElementById('viewerFrame');
     const fileInput = document.getElementById('fileInput');
     const status = document.getElementById('status');
     const header = document.querySelector('header');
     const headerDropZone = document.getElementById('headerDropZone');
+    const mascotDurationInput = document.getElementById('mascotDurationInput');
+    const mascotDurationSummary = document.getElementById('mascotDurationSummary');
     let currentObjectUrl = null;
     let dropZoneDepth = 0;
 
@@ -122,6 +167,14 @@
       postMessageToViewer({ type: 'update-mikankame-visibility' });
     }
 
+    function notifyViewerAboutMascotDuration(minutes) {
+      const durationMinutes = minutes ?? getEffectiveMascotDurationMinutes();
+      postMessageToViewer({
+        type: 'update-mikankame-duration',
+        durationMinutes,
+      });
+    }
+
     function shouldHideMascot() {
       try {
         return localStorage.getItem(MIKANKAME_HIDE_STORAGE_KEY) === 'true';
@@ -129,6 +182,87 @@
         console.warn('Failed to access mikankame preference from localStorage.', error);
         return false;
       }
+    }
+
+    function getStoredMascotDurationMinutes() {
+      try {
+        const stored = localStorage.getItem(MIKANKAME_DURATION_STORAGE_KEY);
+        if (!stored) {
+          return null;
+        }
+
+        const parsed = Number(stored);
+        if (!Number.isFinite(parsed) || parsed <= 0) {
+          return null;
+        }
+
+        return parsed;
+      } catch (error) {
+        console.warn('Failed to read mikankame duration from localStorage.', error);
+        return null;
+      }
+    }
+
+    function getEffectiveMascotDurationMinutes() {
+      return getStoredMascotDurationMinutes() ?? DEFAULT_MASCOT_DURATION_MINUTES;
+    }
+
+    function formatDurationMinutes(minutes) {
+      if (!Number.isFinite(minutes)) {
+        return '';
+      }
+
+      const rounded = Math.round(minutes * 100) / 100;
+      return rounded.toString();
+    }
+
+    function updateMascotDurationSummary(minutes) {
+      if (!mascotDurationSummary) {
+        return;
+      }
+
+      if (!Number.isFinite(minutes) || minutes <= 0) {
+        mascotDurationSummary.textContent = '';
+        return;
+      }
+
+      const seconds = minutes * 60;
+      const minutesText = minutes >= 1
+        ? `${Math.round(minutes * 10) / 10}分`
+        : `${Math.round(minutes * 100) / 100}分`;
+      const secondsText = `${Math.round(seconds)}秒`;
+      mascotDurationSummary.textContent = `(${minutesText} ≒ ${secondsText})`;
+    }
+
+    function updateMascotDurationInput(minutes) {
+      if (!mascotDurationInput) {
+        return;
+      }
+
+      const effectiveMinutes = minutes ?? getEffectiveMascotDurationMinutes();
+      mascotDurationInput.value = formatDurationMinutes(effectiveMinutes);
+      updateMascotDurationSummary(effectiveMinutes);
+    }
+
+    function storeMascotDurationMinutes(minutes) {
+      try {
+        localStorage.setItem(MIKANKAME_DURATION_STORAGE_KEY, String(minutes));
+      } catch (error) {
+        console.warn('Failed to store mikankame duration in localStorage.', error);
+      }
+    }
+
+    function setMascotDurationMinutes(minutes) {
+      if (!Number.isFinite(minutes) || minutes <= 0) {
+        updateMascotDurationInput();
+        status.textContent = '正の数値の分数を入力してください。';
+        return;
+      }
+
+      storeMascotDurationMinutes(minutes);
+      updateMascotDurationInput(minutes);
+      notifyViewerAboutMascotDuration(minutes);
+      status.textContent = `移動時間を約${Math.round(minutes * 10) / 10}分に設定しました。`;
     }
 
     function updateMascotVisibility() {
@@ -260,10 +394,21 @@
 
     viewerFrame.addEventListener('load', () => {
       notifyViewerAboutMascotVisibility();
+      notifyViewerAboutMascotDuration();
       playMascotAnimation();
     });
 
+    mascotDurationInput?.addEventListener('change', () => {
+      const minutes = Number(mascotDurationInput.value);
+      setMascotDurationMinutes(minutes);
+    });
+
+    mascotDurationInput?.addEventListener('blur', () => {
+      updateMascotDurationInput();
+    });
+
     updateMascotVisibility();
+    updateMascotDurationInput();
     setViewerSource(DEFAULT_PDF, 'サンプルPDFを表示しています。');
   </script>
 </body>

--- a/web/mikankame_overlay.js
+++ b/web/mikankame_overlay.js
@@ -1,9 +1,11 @@
-const MASCOT_ANIMATION_DURATION_MS = 8000;
+const MIKANKAME_DURATION_STORAGE_KEY = "mikankameDurationMinutes";
+const DEFAULT_MASCOT_ANIMATION_DURATION_MS = 8000;
 const MASCOT_INITIAL_TRANSFORM = "translateX(0)";
 const MASCOT_FINAL_TRANSFORM = "translateX(calc(100vw - 100% - 32px))";
 let hasCompletedMascotAnimation = false;
 const MIKANKAME_HIDE_STORAGE_KEY = "mikankameHidden";
 const mascotElement = document.getElementById("mikankameOverlay");
+let mascotAnimationDurationMs = DEFAULT_MASCOT_ANIMATION_DURATION_MS;
 
 if (mascotElement) {
   function shouldHideFromSetting() {
@@ -34,6 +36,76 @@ if (mascotElement) {
     return mascotElement.classList.contains("pdfs-mikankame-animating");
   }
 
+  function setMascotAnimationDurationMs(durationMs) {
+    if (!Number.isFinite(durationMs) || durationMs <= 0) {
+      mascotAnimationDurationMs = DEFAULT_MASCOT_ANIMATION_DURATION_MS;
+      mascotElement.style.setProperty(
+        "--mascot-duration",
+        `${DEFAULT_MASCOT_ANIMATION_DURATION_MS}ms`,
+      );
+      return;
+    }
+
+    mascotAnimationDurationMs = durationMs;
+    mascotElement.style.setProperty("--mascot-duration", `${durationMs}ms`);
+  }
+
+  function getStoredMascotDurationMinutes() {
+    try {
+      const stored = localStorage.getItem(MIKANKAME_DURATION_STORAGE_KEY);
+      if (!stored) {
+        return null;
+      }
+
+      const parsed = Number(stored);
+      if (!Number.isFinite(parsed) || parsed <= 0) {
+        return null;
+      }
+
+      return parsed;
+    } catch (error) {
+      console.warn(
+        "Failed to access mikankame duration from localStorage inside the viewer.",
+        error,
+      );
+      return null;
+    }
+  }
+
+  function applyStoredMascotDuration() {
+    const minutes = getStoredMascotDurationMinutes();
+    if (!Number.isFinite(minutes) || minutes <= 0) {
+      setMascotAnimationDurationMs(DEFAULT_MASCOT_ANIMATION_DURATION_MS);
+      return;
+    }
+
+    setMascotAnimationDurationMs(minutes * 60 * 1000);
+  }
+
+  function updateMascotDuration(minutes) {
+    if (!Number.isFinite(minutes) || minutes <= 0) {
+      return;
+    }
+
+    const durationMs = minutes * 60 * 1000;
+    try {
+      localStorage.setItem(MIKANKAME_DURATION_STORAGE_KEY, String(minutes));
+    } catch (error) {
+      console.warn(
+        "Failed to persist mikankame duration inside the viewer.",
+        error,
+      );
+    }
+
+    setMascotAnimationDurationMs(durationMs);
+
+    if (isMascotAnimating()) {
+      mascotElement.classList.remove("pdfs-mikankame-animating");
+      void mascotElement.offsetWidth;
+      mascotElement.classList.add("pdfs-mikankame-animating");
+    }
+  }
+
   function playMascotAnimation() {
     if (shouldHideFromSetting() || hasCompletedMascotAnimation || isMascotAnimating()) {
       return;
@@ -41,10 +113,7 @@ if (mascotElement) {
 
     hasCompletedMascotAnimation = false;
     mascotElement.style.transform = MASCOT_INITIAL_TRANSFORM;
-    mascotElement.style.setProperty(
-      "--mascot-duration",
-      `${MASCOT_ANIMATION_DURATION_MS}ms`,
-    );
+    setMascotAnimationDurationMs(mascotAnimationDurationMs);
     mascotElement.classList.remove("pdfs-mikankame-hidden");
     mascotElement.classList.add("pdfs-mikankame-visible");
     mascotElement.classList.remove("pdfs-mikankame-animating");
@@ -76,6 +145,9 @@ if (mascotElement) {
       case "update-mikankame-visibility":
         updateMascotVisibility();
         break;
+      case "update-mikankame-duration":
+        updateMascotDuration(Number(data.durationMinutes));
+        break;
       default:
         break;
     }
@@ -84,9 +156,18 @@ if (mascotElement) {
   document.addEventListener("DOMContentLoaded", () => {
     mascotElement.style.transform = MASCOT_INITIAL_TRANSFORM;
     updateMascotVisibility();
+    applyStoredMascotDuration();
   });
 
   window.addEventListener("message", handleMessage);
-  window.addEventListener("storage", updateMascotVisibility);
+  window.addEventListener("storage", (event) => {
+    if (!event.key || event.key === MIKANKAME_HIDE_STORAGE_KEY) {
+      updateMascotVisibility();
+    }
+
+    if (!event.key || event.key === MIKANKAME_DURATION_STORAGE_KEY) {
+      applyStoredMascotDuration();
+    }
+  });
   mascotElement.addEventListener("animationend", handleAnimationEnd);
 }


### PR DESCRIPTION
## Summary
- add a header control on the landing page to let users set the Mikankame slide duration in minutes and persist the value
- send the configured duration to the embedded viewer and apply it to the mascot animation, including storage event handling

## Testing
- Manual: opened `http://127.0.0.1:8000/index.html` and adjusted the Mikankame duration control


------
https://chatgpt.com/codex/tasks/task_b_68effccad2748320a9844dcf3a0d5eec