### PR TITLE
Reduce mikankame overlay size and sync animation duration

### DIFF
--- a/web/mikankame_overlay.js
+++ b/web/mikankame_overlay.js
@@ -43,11 +43,16 @@ if (mascotElement) {
         "--mascot-duration",
         `${DEFAULT_MASCOT_ANIMATION_DURATION_MS}ms`,
       );
+      mascotElement.style.setProperty(
+        "animation-duration",
+        `${DEFAULT_MASCOT_ANIMATION_DURATION_MS}ms`,
+      );
       return;
     }
 
     mascotAnimationDurationMs = durationMs;
     mascotElement.style.setProperty("--mascot-duration", `${durationMs}ms`);
+    mascotElement.style.setProperty("animation-duration", `${durationMs}ms`);
   }
 
   function getStoredMascotDurationMinutes() {

--- a/web/viewer.css
+++ b/web/viewer.css
@@ -7281,8 +7281,8 @@ dialog :link{
   position: fixed;
   left: 16px;
   bottom: 16px;
-  width: min(140px, 25vw);
-  max-width: 40vw;
+  width: min(70px, 12.5vw);
+  max-width: 20vw;
   pointer-events: none;
   transform: translateX(0);
   opacity: 0;


### PR DESCRIPTION
## Summary
- shrink the mikankame overlay to half its previous footprint while keeping its fixed positioning
- ensure the overlay's animation duration property mirrors the configured timing value so travel time matches the setting

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68f003ee568c83208b68b8ffff443082