### PR TITLE
Adjust slide UI stacking order for mascot visibility

### DIFF
--- a/web/slide-click.js
+++ b/web/slide-click.js
@@ -141,7 +141,14 @@
     if (document.getElementById('slideUI')) return;
     const ui = document.createElement('div');
     ui.id = 'slideUI';
-    Object.assign(ui.style, { position:'fixed', right:'10px', bottom:'10px', zIndex:'2147483647', display:'flex', gap:'8px' });
+    Object.assign(ui.style, {
+      position: 'fixed',
+      right: '10px',
+      bottom: '10px',
+      zIndex: '2147483646',
+      display: 'flex',
+      gap: '8px',
+    });
 
     modeBtn = document.createElement('button');
     fsBtn   = document.createElement('button');


### PR DESCRIPTION
## Summary
- lower the slide mode control overlay z-index so the mikankame mascot animation remains visible when it reaches the right edge of the screen

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68f0063224ec8320b3e5262c70365bff