### PR TITLE
Allow configuring Mikankame animation via viewer query parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This is a web-based PDF viewer. It now provides a simple landing page that loads
 3. To view your own file, use the **Upload and display a PDF file** control and choose a PDF from your device. The viewer switches to the uploaded file immediately.
 
 You can still open a PDF directly with the viewer by linking to `https://tarosay.github.io/pdfs-viewer/web/viewer.html?file=YOUR_FILE.pdf` if you prefer query-parameter based access.
+When doing so, you may also pass `time` (in seconds) and `animation=on` to immediately start the Mikankame mascot animation with a custom duration, e.g. `...&time=5&animation=on`.
 
 ---
 
@@ -27,6 +28,7 @@ You can still open a PDF directly with the viewer by linking to `https://tarosay
 3. 自分のPDFを閲覧したい場合は、表示されている **PDFファイルをアップロードして表示** コントロールからファイルを選択します。アップロードすると直ちにそのファイルが表示されます。
 
 クエリパラメータを使用して直接PDFを開きたい場合は、`https://tarosay.github.io/pdfs-viewer/web/viewer.html?file=あなたのファイル.pdf` の形式のURLも引き続き利用できます。
+その際は `time`（秒数）と `animation=on` を付けることで、ミカンカメの移動時間を変更した状態で読み込み時にアニメーションを開始できます（例：`...&time=5&animation=on`）。
 
 ### AIでテーマソング
 

--- a/web/mikankame_overlay.js
+++ b/web/mikankame_overlay.js
@@ -6,6 +6,7 @@ let hasCompletedMascotAnimation = false;
 const MIKANKAME_HIDE_STORAGE_KEY = "mikankameHidden";
 const mascotElement = document.getElementById("mikankameOverlay");
 let mascotAnimationDurationMs = DEFAULT_MASCOT_ANIMATION_DURATION_MS;
+let shouldTriggerMascotAnimationFromUrl = false;
 
 if (mascotElement) {
   function shouldHideFromSetting() {
@@ -87,6 +88,45 @@ if (mascotElement) {
     setMascotAnimationDurationMs(minutes * 60 * 1000);
   }
 
+  function applyMascotDurationFromUrl(url) {
+    const timeParam = url.searchParams.get("time");
+    if (timeParam === null) {
+      return;
+    }
+
+    const seconds = Number(timeParam);
+    if (!Number.isFinite(seconds) || seconds <= 0) {
+      return;
+    }
+
+    setMascotAnimationDurationMs(seconds * 1000);
+  }
+
+  function updateAnimationPreferenceFromUrl(url) {
+    const animationParam = url.searchParams.get("animation");
+    if (!animationParam) {
+      return;
+    }
+
+    const normalized = animationParam.trim().toLowerCase();
+    const shouldPlay = ["1", "true", "yes", "on", "start"].includes(normalized);
+    shouldTriggerMascotAnimationFromUrl =
+      shouldTriggerMascotAnimationFromUrl || shouldPlay;
+  }
+
+  function applyMascotConfigurationFromUrl() {
+    let url;
+    try {
+      url = new URL(window.location.href);
+    } catch (error) {
+      console.warn("Failed to parse the current URL for mascot configuration.", error);
+      return;
+    }
+
+    applyMascotDurationFromUrl(url);
+    updateAnimationPreferenceFromUrl(url);
+  }
+
   function updateMascotDuration(minutes) {
     if (!Number.isFinite(minutes) || minutes <= 0) {
       return;
@@ -162,6 +202,13 @@ if (mascotElement) {
     mascotElement.style.transform = MASCOT_INITIAL_TRANSFORM;
     updateMascotVisibility();
     applyStoredMascotDuration();
+    applyMascotConfigurationFromUrl();
+
+    if (shouldTriggerMascotAnimationFromUrl && !shouldHideFromSetting()) {
+      requestAnimationFrame(() => {
+        playMascotAnimation();
+      });
+    }
   });
 
   window.addEventListener("message", handleMessage);


### PR DESCRIPTION
## Summary
- parse the viewer URL for `time` and `animation` query parameters to configure the Mikankame mascot duration and autoplay when accessed directly
- document the new query parameter support in both English and Japanese sections of the README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68f009222de0832097876f7fe941c233