### PR TITLE
Adjust mascot URL parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is a web-based PDF viewer. It now provides a simple landing page that loads
 3. To view your own file, use the **Upload and display a PDF file** control and choose a PDF from your device. The viewer switches to the uploaded file immediately.
 
 You can still open a PDF directly with the viewer by linking to `https://tarosay.github.io/pdfs-viewer/web/viewer.html?file=YOUR_FILE.pdf` if you prefer query-parameter based access.
-When doing so, you may also pass `time` (in seconds) and `animation=on` to immediately start the Mikankame mascot animation with a custom duration, e.g. `...&time=5&animation=on`.
+When doing so, you may also pass `time` (in minutes) and `animation=on` to immediately start the Mikankame mascot animation with a custom duration, e.g. `...&time=5&animation=on`. Passing `animation=off` hides the mascot entirely for that load.
 
 ---
 
@@ -28,7 +28,7 @@ When doing so, you may also pass `time` (in seconds) and `animation=on` to immed
 3. 自分のPDFを閲覧したい場合は、表示されている **PDFファイルをアップロードして表示** コントロールからファイルを選択します。アップロードすると直ちにそのファイルが表示されます。
 
 クエリパラメータを使用して直接PDFを開きたい場合は、`https://tarosay.github.io/pdfs-viewer/web/viewer.html?file=あなたのファイル.pdf` の形式のURLも引き続き利用できます。
-その際は `time`（秒数）と `animation=on` を付けることで、ミカンカメの移動時間を変更した状態で読み込み時にアニメーションを開始できます（例：`...&time=5&animation=on`）。
+その際は `time`（分）と `animation=on` を付けることで、ミカンカメの移動時間を変更した状態で読み込み時にアニメーションを開始できます（例：`...&time=5&animation=on`）。`animation=off` を指定すると、その読み込みではミカンカメを非表示にできます。
 
 ### AIでテーマソング
 

--- a/web/mikankame_overlay.js
+++ b/web/mikankame_overlay.js
@@ -7,6 +7,7 @@ const MIKANKAME_HIDE_STORAGE_KEY = "mikankameHidden";
 const mascotElement = document.getElementById("mikankameOverlay");
 let mascotAnimationDurationMs = DEFAULT_MASCOT_ANIMATION_DURATION_MS;
 let shouldTriggerMascotAnimationFromUrl = false;
+let shouldHideMascotFromUrl = false;
 
 if (mascotElement) {
   function shouldHideFromSetting() {
@@ -22,7 +23,7 @@ if (mascotElement) {
   }
 
   function updateMascotVisibility() {
-    const shouldShow = !shouldHideFromSetting();
+    const shouldShow = !shouldHideFromSetting() && !shouldHideMascotFromUrl;
     mascotElement.classList.toggle("pdfs-mikankame-hidden", !shouldShow);
     mascotElement.classList.toggle("pdfs-mikankame-visible", shouldShow);
 
@@ -94,12 +95,12 @@ if (mascotElement) {
       return;
     }
 
-    const seconds = Number(timeParam);
-    if (!Number.isFinite(seconds) || seconds <= 0) {
+    const minutes = Number(timeParam);
+    if (!Number.isFinite(minutes) || minutes <= 0) {
       return;
     }
 
-    setMascotAnimationDurationMs(seconds * 1000);
+    setMascotAnimationDurationMs(minutes * 60 * 1000);
   }
 
   function updateAnimationPreferenceFromUrl(url) {
@@ -110,8 +111,13 @@ if (mascotElement) {
 
     const normalized = animationParam.trim().toLowerCase();
     const shouldPlay = ["1", "true", "yes", "on", "start"].includes(normalized);
+    const shouldHide = ["0", "false", "no", "off", "stop"].includes(normalized);
     shouldTriggerMascotAnimationFromUrl =
       shouldTriggerMascotAnimationFromUrl || shouldPlay;
+
+    if (shouldHide) {
+      shouldHideMascotFromUrl = true;
+    }
   }
 
   function applyMascotConfigurationFromUrl() {
@@ -200,9 +206,9 @@ if (mascotElement) {
 
   document.addEventListener("DOMContentLoaded", () => {
     mascotElement.style.transform = MASCOT_INITIAL_TRANSFORM;
-    updateMascotVisibility();
     applyStoredMascotDuration();
     applyMascotConfigurationFromUrl();
+    updateMascotVisibility();
 
     if (shouldTriggerMascotAnimationFromUrl && !shouldHideFromSetting()) {
       requestAnimationFrame(() => {


### PR DESCRIPTION
## Summary
- interpret the `time` URL parameter as minutes when configuring the Mikankame animation
- allow `animation=off` in the URL to hide the mascot for the current load
- document the updated URL parameter behaviour in both English and Japanese README sections

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68f00c265d788320a7c8732f6b78cc00